### PR TITLE
Added mixing ratio labels

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -45,7 +45,8 @@ def background():
         "isotherms":      _lines["isotherms"].T.tolist(),
         "dry_adiabats":   _lines["dry_adiabats"].T.tolist(),
         "moist_adiabats": _lines["moist_adiabats"].T.tolist(),
-        "isohumes":       _lines["isohumes"].T.tolist(),
+        "isohumes":               _lines["isohumes"].T.tolist(),
+        "isohume_mixing_ratios":  _lines["isohume_mixing_ratios"].tolist(),
     }
 
 

--- a/api/skewT.py
+++ b/api/skewT.py
@@ -60,15 +60,20 @@ def get_static_lines(ktot=64):
 
     # Isohumes: lines of constant specific humidity.
     x = x0_isohumes + thrm.T0
-    isohumes = thrm.dewpoint(thrm.qsat(x, thrm.p0)[np.newaxis, :], p_isohumes[:, np.newaxis])
+    q_isohumes = thrm.qsat(x, thrm.p0)
+    isohumes = thrm.dewpoint(q_isohumes[np.newaxis, :], p_isohumes[:, np.newaxis])
+
+    # Mixing ratio in g/kg for each isohume (used for labeling).
+    isohume_mixing_ratios = q_isohumes / (1 - q_isohumes) * 1000
 
     return {
-        "p_isotherms":    p_isotherms,
-        "p_dry":          p_dry,
-        "p_moist":        p_moist,
-        "p_isohumes":     p_isohumes,
-        "isotherms":      isotherms,
-        "dry_adiabats":   dry_adiabats,
-        "moist_adiabats": moist_adiabats,
-        "isohumes":       isohumes,
+        "p_isotherms":            p_isotherms,
+        "p_dry":                  p_dry,
+        "p_moist":                p_moist,
+        "p_isohumes":             p_isohumes,
+        "isotherms":              isotherms,
+        "dry_adiabats":           dry_adiabats,
+        "moist_adiabats":         moist_adiabats,
+        "isohumes":               isohumes,
+        "isohume_mixing_ratios":  isohume_mixing_ratios,
     }

--- a/api/skewT.py
+++ b/api/skewT.py
@@ -44,7 +44,7 @@ def get_static_lines(ktot=64):
     x0_isotherms      = np.arange(-120, 40.01, 10)
     x0_dry_adiabats   = np.arange( -40, 50.01, 10)
     x0_moist_adiabats = np.array([0, 5, 10, 12.5, 15, 17.5, 20, 22.5, 25, 27.5])
-    x0_isohumes       = np.arange( -30, 30.01, 10)
+    r_isohumes        = np.array([0.5, 1, 2, 4, 8, 15, 30])  # g/kg
 
     # Isotherms: lines of constant absolute temperature.
     x = x0_isotherms + thrm.T0
@@ -58,13 +58,10 @@ def get_static_lines(ktot=64):
     x = x0_moist_adiabats + thrm.T0
     moist_adiabats = thrm.calc_moist_adiabat(x, p_moist)
 
-    # Isohumes: lines of constant specific humidity.
-    x = x0_isohumes + thrm.T0
-    q_isohumes = thrm.qsat(x, thrm.p0)
+    # Isohumes: lines of constant mixing ratio.
+    q_isohumes = r_isohumes / (1000 + r_isohumes)
     isohumes = thrm.dewpoint(q_isohumes[np.newaxis, :], p_isohumes[:, np.newaxis])
-
-    # Mixing ratio in g/kg for each isohume (used for labeling).
-    isohume_mixing_ratios = q_isohumes / (1 - q_isohumes) * 1000
+    isohume_mixing_ratios = r_isohumes.astype(float)
 
     return {
         "p_isotherms":            p_isotherms,

--- a/web/index.html
+++ b/web/index.html
@@ -201,6 +201,10 @@
                             <input type="checkbox" id="show_isohumes" checked>
                             Mixing ratios <span style="color:#1f77b4"><b>&mdash;&mdash;&mdash;</b></span>
                         </label>
+                        <label style="padding-left: 1.5rem;">
+                            <input type="checkbox" id="label_isohumes" checked>
+                            Label values (g/kg)
+                        </label>
                         <label>
                             <input type="checkbox" id="show_dry_adiabats" checked>
                             Dry adiabats <span style="color:#d62728"><b>&mdash;&mdash;&mdash;</b></span>

--- a/web/skewt.js
+++ b/web/skewt.js
@@ -228,7 +228,7 @@ function draw_isohume_labels(chart, x, y, isohumes, p_isohumes_pa, mixing_ratios
             .attr("x", x_pos)
             .attr("y", y_pos - 4)
             .attr("text-anchor", "middle")
-            .attr("font-size", "10px")
+            .attr("font-size", "12px")
             .attr("fill", "rgba(31,119,180,0.9)")
             .text(mixing_ratios[i].toFixed(1));
     });

--- a/web/skewt.js
+++ b/web/skewt.js
@@ -160,7 +160,12 @@ document.getElementById("fire_area").addEventListener("input", (e) =>
 });
 document.getElementById("show_isobars").addEventListener("change", draw_skewt);
 document.getElementById("show_isotherms").addEventListener("change", draw_skewt);
-document.getElementById("show_isohumes").addEventListener("change", draw_skewt);
+document.getElementById("show_isohumes").addEventListener("change", () =>
+{
+    document.getElementById("label_isohumes").disabled = !document.getElementById("show_isohumes").checked;
+    draw_skewt();
+});
+document.getElementById("label_isohumes").addEventListener("change", draw_skewt);
 document.getElementById("show_dry_adiabats").addEventListener("change", draw_skewt);
 document.getElementById("show_moist_adiabats").addEventListener("change", draw_skewt);
 document.getElementById("edit_mode").addEventListener("change", draw_skewt);
@@ -209,6 +214,26 @@ function draw_skewt_lines(chart, x, y, temps, pressures_pa, color)
     });
 }
 
+function draw_isohume_labels(chart, x, y, isohumes, p_isohumes_pa, mixing_ratios)
+{
+    const p_top_hpa = p_isohumes_pa[p_isohumes_pa.length - 1] / 100;
+
+    isohumes.forEach((line, i) =>
+    {
+        const T_top = line[line.length - 1];
+        const x_pos = x(skew_transform(T_top, p_top_hpa));
+        const y_pos = y(p_top_hpa);
+
+        chart.append("text")
+            .attr("x", x_pos)
+            .attr("y", y_pos - 4)
+            .attr("text-anchor", "middle")
+            .attr("font-size", "10px")
+            .attr("fill", "rgba(31,119,180,0.9)")
+            .text(mixing_ratios[i].toFixed(1));
+    });
+}
+
 function draw_skewt()
 {
     svg.selectAll("*").remove();
@@ -253,7 +278,11 @@ function draw_skewt()
         if (document.getElementById("show_isotherms").checked)
             draw_skewt_lines(chart, x, y, bg_data.isotherms,      bg_data.p_isotherms, "rgba(179,179,179,0.5)");
         if (document.getElementById("show_isohumes").checked)
-            draw_skewt_lines(chart, x, y, bg_data.isohumes,       bg_data.p_isohumes,  "rgba(31,119,180,0.5)");
+        {
+            draw_skewt_lines(chart, x, y, bg_data.isohumes, bg_data.p_isohumes, "rgba(31,119,180,0.5)");
+            if (document.getElementById("label_isohumes").checked)
+                draw_isohume_labels(chart, x, y, bg_data.isohumes, bg_data.p_isohumes, bg_data.isohume_mixing_ratios);
+        }
         if (document.getElementById("show_dry_adiabats").checked)
             draw_skewt_lines(chart, x, y, bg_data.dry_adiabats,   bg_data.p_dry,       "rgba(214,39,40,0.5)");
         if (document.getElementById("show_moist_adiabats").checked)


### PR DESCRIPTION
Claude has added (optional) mixing ratio labels where the isohumes end. I have checked it doesn't break on zooming/panning or anything else. They are on by default; you can turn them off in the Plot options if they bother you.

One could still consider moving the isohumes to places where the mixing ratios are round numbers.