### PR TITLE
Fixed dT/dp calculation.

### DIFF
--- a/api/skewT.py
+++ b/api/skewT.py
@@ -42,7 +42,7 @@ def get_static_lines(ktot=64):
     # Start points (temperature in Celsius at 1000 hPa) of static lines.
     x0_isotherms      = np.arange(-120, 40.01, 10)
     x0_dry_adiabats   = np.arange( -40, 50.01, 10)
-    x0_moist_adiabats = np.array([0, 5, 10, 12.5, 15, 17.5, 20, 22.5, 25, 27.5])
+    x0_moist_adiabats = np.array([0, 5, 10, 15, 20, 25, 30, 35, 40])
     r_isohumes        = np.array([0.5, 1, 2, 4, 8, 15, 30])  # g/kg
 
     # Isotherms: lines of constant absolute temperature.

--- a/api/thermo.py
+++ b/api/thermo.py
@@ -251,7 +251,7 @@ def dTdp(T, p):
         Temperature tendency with respect to pressure in K/Pa.
     """
     qs = qsat(T, p)
-    return (T / p) * (Rd + Lv * qs / (Rd * T)) \
+    return (T / p) * (Rd + Lv * qs / T) \
                     / (cp + Lv**2 * qs / (Rv * T**2))
 
 

--- a/web/parcel.js
+++ b/web/parcel.js
@@ -191,8 +191,15 @@ export function calc_entraining_parcel(
     // Cap Td at T: above LCL the parcel is saturated so Td == T.
     const Td_out = qt_out.map((q, k) => Math.min(dewpoint(q, p_out[k]), T_out[k]));
 
+    // Post-process: pseudoadiabatic T above LCL so the line follows background theta_e lines.
+    const lcl_k     = Array.from(type_p.slice(0, i)).indexOf(1);
+    const T_pseudo  = lcl_k === -1
+        ? T_out.slice()
+        : [...T_out.slice(0, lcl_k), ...calc_moist_adiabat(T_out[lcl_k], p_out.slice(lcl_k))];
+
     return {
         T:           T_out,
+        T_pseudo:    T_pseudo,
         Tv:          sl(Tv_p),
         Td:          Td_out,
         theta:       sl(theta_p),

--- a/web/skewt.js
+++ b/web/skewt.js
@@ -459,7 +459,7 @@ function draw_skewt()
                 const lcl_idx = parcel.type.indexOf(1);
                 const n_sub   = lcl_idx === -1 ? parcel.p.length : lcl_idx + 1;
                 draw_parcel_segments([
-                    [parcel.p,                 parcel.T],
+                    [parcel.p,                 parcel.T_pseudo],
                     [parcel.p.slice(0, n_sub), parcel.Td.slice(0, n_sub)],
                 ]);
             }

--- a/web/thermo.js
+++ b/web/thermo.js
@@ -108,7 +108,7 @@ export function sat_adjust(thl, qt, p)
 export function dTdp(T, p)
 {
     const qs = qsat(T, p);
-    return (T / p) * (Rd + Lv * qs / (Rd * T))
+    return (T / p) * (Rd + Lv * qs / T)
                    / (cp + Lv**2 * qs / (Rv * T**2));
 }
 


### PR DESCRIPTION
Ugly bug in the `dT/dp` calculation: If I follow the moist adiabat in a refernce diagram (NCL) from 20 degrees to 400 hPa, the temperature should be around -20.

Old:
<img width="2001" height="1272" alt="Screenshot from 2026-05-13 10-40-05" src="https://github.com/user-attachments/assets/19eeb84f-0cb6-4063-a1ac-9aaebb519e43" />

Fixed:
<img width="2001" height="1272" alt="fixed" src="https://github.com/user-attachments/assets/dd95ab5c-0de7-4efa-8d97-64c51e88f6cf" />


