### PR TITLE
Fix thermo theta_l

### DIFF
--- a/api/open_meteo.py
+++ b/api/open_meteo.py
@@ -184,7 +184,7 @@ def get_model_sounding(lat, lon, model, date_str):
     exn = thrm.exner(p[np.newaxis, :])
     theta  = meteo['temperature'] / exn
     thetav = thrm.virtual_temp(theta, qt, ql=ql)
-    thetal = theta - thrm.Lv * ql / (thrm.cp * exn)
+    thetal = thrm.thetal(theta, ql, meteo['temperature'])
 
     wd_rad = np.deg2rad(meteo['wind_direction'])
     u = -meteo['wind_speed'] * np.sin(wd_rad)

--- a/api/thermo.py
+++ b/api/thermo.py
@@ -151,6 +151,27 @@ def virtual_temp(T, qt, ql=0, qi=0):
     return T * (1 + (Rv/Rd - 1) * qt - Rv/Rd * (ql + qi))
 
 
+def thetal(theta, ql, T):
+    """
+    Compute liquid-water potential temperature using the full exponential form.
+
+    Parameters:
+    ----------
+    theta : float or np.ndarray
+        Potential temperature in K.
+    ql : float or np.ndarray
+        Liquid water specific humidity in kg/kg.
+    T : float or np.ndarray
+        Temperature in K.
+
+    Returns:
+    -------
+    float or np.ndarray
+        Liquid-water potential temperature in K.
+    """
+    return theta * np.exp(-Lv * ql / (cp * T))
+
+
 def dqsatdT(T, p):
     """
     Compute d(qsat)/dT, consistent with the Bolton esat and qsat formulations.
@@ -174,7 +195,7 @@ def dqsatdT(T, p):
     return eps * p * des_dT / den ** 2
 
 
-def sat_adjust(thl, qt, p, use_ice=False):
+def sat_adjust(thetal, qt, p, use_ice=False):
     """
     Saturation adjustment (warm, liquid-only).
 
@@ -184,7 +205,7 @@ def sat_adjust(thl, qt, p, use_ice=False):
 
     Parameters:
     ----------
-    thl : float
+    thetal : float
         Liquid-water potential temperature [K].
     qt : float
         Total water specific humidity [kg/kg].
@@ -204,7 +225,8 @@ def sat_adjust(thl, qt, p, use_ice=False):
     qs : float
         Saturation specific humidity [kg/kg].
     """
-    tl = thl * exner(p)
+    pi = exner(p)
+    tl = thetal * pi
     qs = qsat(tl, p)
 
     if qt - qs <= 0.0:
@@ -216,9 +238,11 @@ def sat_adjust(thl, qt, p, use_ice=False):
     while abs(tnr - tnr_old) / tnr_old > 1e-5 and niter < 10:
         niter += 1
         tnr_old = tnr
-        qs = qsat(tnr, p)
-        f = tnr - tl - Lv / cp * (qt - qs)
-        f_prime = 1.0 + Lv / cp * dqsatdT(tnr, p)
+        qs    = qsat(tnr, p)
+        ql    = qt - qs
+        exp_A = np.exp(-Lv * ql / (cp * tnr))
+        f       = tnr * exp_A - tl
+        f_prime = exp_A * (1.0 + Lv / cp * (dqsatdT(tnr, p) + ql / tnr))
         tnr -= f / f_prime
 
     qs = qsat(tnr, p)

--- a/web/parcel.js
+++ b/web/parcel.js
@@ -121,7 +121,7 @@ export function calc_entraining_parcel(
     const rho_e    = p_e.map((p, k) => p / (Rd * exner_e[k] * thetav_e[k]));
 
     // Allocate parcel arrays.
-    const theta_p  = new Array(n);
+    const thetal_p = new Array(n);
     const qt_p     = new Array(n);
     const thetav_p = new Array(n);
     const T_p      = new Array(n);
@@ -133,11 +133,12 @@ export function calc_entraining_parcel(
     const det_p    = new Array(n);
     const type_p   = new Array(n).fill(0);
 
-    // Initial conditions.
-    theta_p[0] = theta_e[0] + fire_multiplier * dtheta_plume_s;
-    qt_p[0]    = qt_e[0]    + fire_multiplier * dq_plume_s;
+    // Initial conditions. Fire perturbation is a dry heat excess (ql=0 at source),
+    // so thetal_p == theta_p at the surface.
+    thetal_p[0] = theta_e[0] + fire_multiplier * dtheta_plume_s;
+    qt_p[0]     = qt_e[0]    + fire_multiplier * dq_plume_s;
 
-    let { T, ql, qi } = sat_adjust(theta_p[0], qt_p[0], p_e[0]);
+    let { T, ql, qi } = sat_adjust(thetal_p[0], qt_p[0], p_e[0]);
     T_p[0]      = T;
     Tv_p[0]     = virtual_temp(T, qt_p[0], ql, qi);
     thetav_p[0] = Tv_p[0]/exner_e[0];
@@ -157,11 +158,14 @@ export function calc_entraining_parcel(
     let i = 1;
     for (; i < n; i++)
     {
-        mf_p[i]    = mf_p[i-1] + (ent_p[i-1] - det_p[i-1]) * dz;
-        theta_p[i] = theta_p[i-1] - ent_p[i-1] * (theta_p[i-1] - theta_e[i-1]) / mf_p[i-1] * dz;
-        qt_p[i]    = qt_p[i-1]    - ent_p[i-1] * (qt_p[i-1]    - qt_e[i-1])    / mf_p[i-1] * dz;
+        mf_p[i]     = mf_p[i-1] + (ent_p[i-1] - det_p[i-1]) * dz;
+        // TODO: use thetal_e here instead of theta_e. Currently theta_e == thetal_e only
+        // because the environment is assumed unsaturated (ql_e = 0). If the environment
+        // is saturated, entrained air carries condensate and theta_e > thetal_e.
+        thetal_p[i] = thetal_p[i-1] - ent_p[i-1] * (thetal_p[i-1] - theta_e[i-1]) / mf_p[i-1] * dz;
+        qt_p[i]     = qt_p[i-1]     - ent_p[i-1] * (qt_p[i-1]     - qt_e[i-1])    / mf_p[i-1] * dz;
 
-        ({ T, ql, qi } = sat_adjust(theta_p[i], qt_p[i], p_e[i]));
+        ({ T, ql, qi } = sat_adjust(thetal_p[i], qt_p[i], p_e[i]));
         T_p[i]      = T;
         Tv_p[i]     = virtual_temp(T, qt_p[i], ql, qi);
         thetav_p[i] = Tv_p[i] / exner_e[i];
@@ -202,7 +206,7 @@ export function calc_entraining_parcel(
         T_pseudo:    T_pseudo,
         Tv:          sl(Tv_p),
         Td:          Td_out,
-        theta:       sl(theta_p),
+        thetal:      sl(thetal_p),
         thetav:      sl(thetav_p),
         qt:          qt_out,
         area:        sl(area_p),

--- a/web/parcel.js
+++ b/web/parcel.js
@@ -166,8 +166,13 @@ export function calc_entraining_parcel(
         qt_p[i]     = qt_p[i-1]     - ent_p[i-1] * (qt_p[i-1]     - qt_e[i-1])    / mf_p[i-1] * dz;
 
         ({ T, ql, qi } = sat_adjust(thetal_p[i], qt_p[i], p_e[i]));
+
+        // Pseudoadiabatic: remove condensate so it does not accumulate in the parcel.
+        qt_p[i]    -= ql;
+        thetal_p[i] = T / exner_e[i];
+
         T_p[i]      = T;
-        Tv_p[i]     = virtual_temp(T, qt_p[i], ql, qi);
+        Tv_p[i]     = virtual_temp(T, qt_p[i], 0, 0);
         thetav_p[i] = Tv_p[i] / exner_e[i];
 
         if (ql > 0 || qi > 0)

--- a/web/skewt.js
+++ b/web/skewt.js
@@ -459,7 +459,7 @@ function draw_skewt()
                 const lcl_idx = parcel.type.indexOf(1);
                 const n_sub   = lcl_idx === -1 ? parcel.p.length : lcl_idx + 1;
                 draw_parcel_segments([
-                    [parcel.p,                 parcel.T_pseudo],
+                    [parcel.p,                 parcel.T],
                     [parcel.p.slice(0, n_sub), parcel.Td.slice(0, n_sub)],
                 ]);
             }

--- a/web/thermo.js
+++ b/web/thermo.js
@@ -79,9 +79,16 @@ export function virtual_temp(T, qt, ql=0, qi=0)
 }
 
 
-export function sat_adjust(thl, qt, p)
+export function thetal(theta, ql, T)
 {
-    const tl = thl * exner(p);
+    return theta * Math.exp(-Lv * ql / (cp * T));
+}
+
+
+export function sat_adjust(thetal, qt, p)
+{
+    const pi = exner(p);
+    const tl = thetal * pi;
     let qs = qsat(tl, p);
 
     if (qt - qs <= 0.0)
@@ -94,8 +101,10 @@ export function sat_adjust(thl, qt, p)
         niter++;
         tnr_old = tnr;
         qs = qsat(tnr, p);
-        const f       = tnr - tl - Lv / cp * (qt - qs);
-        const f_prime = 1.0 + Lv / cp * dqsatdT(tnr, p);
+        const ql    = qt - qs;
+        const exp_A = Math.exp(-Lv * ql / (cp * tnr));
+        const f       = tnr * exp_A - tl;
+        const f_prime = exp_A * (1.0 + Lv / cp * (dqsatdT(tnr, p) + ql / tnr));
         tnr -= f / f_prime;
     }
 


### PR DESCRIPTION
I have now:
- Made explicit in the plume model code that it is conserving `thetal`, not `theta` by renaming
- Reformulated the plume model in terms of `thetal = theta*exp(Lv*ql/(cp*T))`, and modified the saturation adjustment to match this (see photo of derivation)
- Made the plume model pseudoadiabatic, by removing `ql` from `qt` after the thermodynamics, and then also not accounting for `ql` loading in the virtual temperature calculation. This is of course a big assumption, but it's really also there in the `dTdp` we use now. There is evidence that a reversible adiabat might be a better approximation of real convection, i.e. keeping the liquid water, but that would require a different formulation of `theta_l` (since we'd have to account for the `ql`'s impact on the heat capacity) and a different `dTdp`. This is something that should be tested in LES, ideally.

<img width="4096" height="3072" alt="IMG_20260520_095952436" src="https://github.com/user-attachments/assets/30ccce04-cba1-47a5-9d12-32d550963ab4" />