### PR TITLE
Add surface model

### DIFF
--- a/api/open_meteo.py
+++ b/api/open_meteo.py
@@ -184,7 +184,7 @@ def get_model_sounding(lat, lon, model, date_str):
     exn = thrm.exner(p[np.newaxis, :])
     theta  = meteo['temperature'] / exn
     thetav = thrm.virtual_temp(theta, qt, ql=ql)
-    thetal = theta - thrm.Lv * ql / (thrm.cp * exn)
+    thetal = thrm.thetal(theta, ql, meteo['temperature'])
 
     wd_rad = np.deg2rad(meteo['wind_direction'])
     u = -meteo['wind_speed'] * np.sin(wd_rad)

--- a/api/thermo.py
+++ b/api/thermo.py
@@ -151,6 +151,27 @@ def virtual_temp(T, qt, ql=0, qi=0):
     return T * (1 + (Rv/Rd - 1) * qt - Rv/Rd * (ql + qi))
 
 
+def thetal(theta, ql, T):
+    """
+    Compute liquid-water potential temperature using the full exponential form.
+
+    Parameters:
+    ----------
+    theta : float or np.ndarray
+        Potential temperature in K.
+    ql : float or np.ndarray
+        Liquid water specific humidity in kg/kg.
+    T : float or np.ndarray
+        Temperature in K.
+
+    Returns:
+    -------
+    float or np.ndarray
+        Liquid-water potential temperature in K.
+    """
+    return theta * np.exp(-Lv * ql / (cp * T))
+
+
 def dqsatdT(T, p):
     """
     Compute d(qsat)/dT, consistent with the Bolton esat and qsat formulations.
@@ -174,7 +195,7 @@ def dqsatdT(T, p):
     return eps * p * des_dT / den ** 2
 
 
-def sat_adjust(thl, qt, p, use_ice=False):
+def sat_adjust(thetal, qt, p, use_ice=False):
     """
     Saturation adjustment (warm, liquid-only).
 
@@ -184,7 +205,7 @@ def sat_adjust(thl, qt, p, use_ice=False):
 
     Parameters:
     ----------
-    thl : float
+    thetal : float
         Liquid-water potential temperature [K].
     qt : float
         Total water specific humidity [kg/kg].
@@ -204,7 +225,8 @@ def sat_adjust(thl, qt, p, use_ice=False):
     qs : float
         Saturation specific humidity [kg/kg].
     """
-    tl = thl * exner(p)
+    pi = exner(p)
+    tl = thetal * pi
     qs = qsat(tl, p)
 
     if qt - qs <= 0.0:
@@ -216,9 +238,11 @@ def sat_adjust(thl, qt, p, use_ice=False):
     while abs(tnr - tnr_old) / tnr_old > 1e-5 and niter < 10:
         niter += 1
         tnr_old = tnr
-        qs = qsat(tnr, p)
-        f = tnr - tl - Lv / cp * (qt - qs)
-        f_prime = 1.0 + Lv / cp * dqsatdT(tnr, p)
+        qs    = qsat(tnr, p)
+        ql    = qt - qs
+        exp_A = np.exp(-Lv * ql / (cp * tnr))
+        f       = tnr * exp_A - tl
+        f_prime = exp_A * (1.0 + Lv / cp * (dqsatdT(tnr, p) + ql / tnr))
         tnr -= f / f_prime
 
     qs = qsat(tnr, p)

--- a/web/fire_surface.js
+++ b/web/fire_surface.js
@@ -18,37 +18,35 @@ import { cp, Lv, g } from "./thermo.js";
 import { A_W, B_W, H0_PLUME } from "./parcel.js";
 
 
-// Forward: Given (H, LE) calculate (dtheta, dq, w0) at top of surface layer
-export function compute_fire_surface(H, LE, rho, theta, thetav)
+// w0² = K·dθ  (K = 3·g·A_W·H0 / (2·θv·(1+B_W))), derived from w0³ = C·H, H = ρ·cp·dθ·w0.
+export function w0_from_dtheta(dtheta, thetav)
 {
-    const Fv = H + 0.61 * cp * theta * LE / Lv;
-    if (Fv <= 0)
-        return { dtheta: 0, dq: 0, w0: 0 };
-
-    const w0 = Math.cbrt(3 * g * A_W * H0_PLUME * Fv
-                         / (2 * rho * cp * thetav * (1 + B_W)));
-
-    return {
-        dtheta: H  / (rho * cp * w0),
-        dq:     LE / (rho * Lv * w0),
-        w0,
-    };
+    if (dtheta <= 0) return 0;
+    return Math.sqrt(3 * g * A_W * H0_PLUME * dtheta / (2 * thetav * (1 + B_W)));
 }
 
-// Inverse: Given (dtheta, dq) calculate (H, LE, w0).
-export function invert_fire_surface(dtheta, dq, rho, theta, thetav)
+// Slider → state.
+export function dtheta_from_H(H, rho, thetav)
 {
-    const w0_sq = 3 * g * A_W * H0_PLUME
-                  / (2 * thetav * (1 + B_W))
-                  * (dtheta + 0.61 * theta * dq);
+    if (H <= 0) return 0;
+    const K = 3 * g * A_W * H0_PLUME / (2 * thetav * (1 + B_W));
+    return Math.pow(H / (rho * cp * Math.sqrt(K)), 2 / 3);
+}
 
-    if (w0_sq <= 0)
-        return { H: 0, LE: 0, w0: 0 };
+export function dq_from_LE(LE, dtheta, rho, thetav)
+{
+    const w0 = w0_from_dtheta(dtheta, thetav);
+    if (w0 <= 0) return 0;
+    return LE / (rho * Lv * w0);
+}
 
-    const w0 = Math.sqrt(w0_sq);
-    return {
-        H:  rho * cp * w0 * dtheta,
-        LE: rho * Lv * w0 * dq,
-        w0,
-    };
+// State → display.
+export function H_from_dtheta(dtheta, rho, thetav)
+{
+    return rho * cp * dtheta * w0_from_dtheta(dtheta, thetav);
+}
+
+export function LE_from_dq(dq, dtheta, rho, thetav)
+{
+    return rho * Lv * dq * w0_from_dtheta(dtheta, thetav);
 }

--- a/web/fire_surface.js
+++ b/web/fire_surface.js
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 Wageningen University & Research (WUR)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { cp, Lv, g } from "./thermo.js";
+import { A_W, B_W, H0_PLUME } from "./parcel.js";
+
+
+// Forward: Given (H, LE) calculate (dtheta, dq, w0) at top of surface layer
+export function compute_fire_surface(H, LE, rho, theta, thetav)
+{
+    const Fv = H + 0.61 * cp * theta * LE / Lv;
+    if (Fv <= 0)
+        return { dtheta: 0, dq: 0, w0: 0 };
+
+    const w0 = Math.cbrt(3 * g * A_W * H0_PLUME * Fv
+                         / (2 * rho * cp * thetav * (1 + B_W)));
+
+    return {
+        dtheta: H  / (rho * cp * w0),
+        dq:     LE / (rho * Lv * w0),
+        w0,
+    };
+}
+
+// Inverse: Given (dtheta, dq) calculate (H, LE, w0).
+export function invert_fire_surface(dtheta, dq, rho, theta, thetav)
+{
+    const w0_sq = 3 * g * A_W * H0_PLUME
+                  / (2 * thetav * (1 + B_W))
+                  * (dtheta + 0.61 * theta * dq);
+
+    if (w0_sq <= 0)
+        return { H: 0, LE: 0, w0: 0 };
+
+    const w0 = Math.sqrt(w0_sq);
+    return {
+        H:  rho * cp * w0 * dtheta,
+        LE: rho * Lv * w0 * dq,
+        w0,
+    };
+}

--- a/web/index.html
+++ b/web/index.html
@@ -147,6 +147,14 @@
                             <span id="fire_area_label">Fire area: 1.0 km²</span>
                             <input type="range" id="fire_area" min="5" max="7" step="0.1" value="6">
                         </label>
+                        <label>
+                            <span id="fire_H_label">Sensible heat flux: 0 kW/m²</span>
+                            <input type="range" id="fire_H" min="0" max="250" step="1" value="0">
+                        </label>
+                        <label>
+                            <span id="fire_LE_label">Latent heat flux: 0 kW/m²</span>
+                            <input type="range" id="fire_LE" min="0" max="50" step="0.5" value="0">
+                        </label>
                     </div>
                 </details>
 

--- a/web/index.html
+++ b/web/index.html
@@ -149,7 +149,7 @@
                         </label>
                         <label>
                             <span id="fire_H_label">Sensible heat flux: 0 kW/m²</span>
-                            <input type="range" id="fire_H" min="0" max="250" step="1" value="0">
+                            <input type="range" id="fire_H" min="0" max="250" step="0.5" value="0">
                         </label>
                         <label>
                             <span id="fire_LE_label">Latent heat flux: 0 kW/m²</span>

--- a/web/parcel.js
+++ b/web/parcel.js
@@ -17,13 +17,6 @@
 import { Rd, g, exner, qsat, dewpoint, calc_moist_adiabat, sat_adjust, virtual_temp } from "./thermo.js";
 
 
-// Entraining plume model constants.
-//   A_W, B_W   — buoyancy and entrainment scalings of w (Morton).
-//   FAC_ENT    — fractional entrainment coefficient.
-//   BETA       — entrainment-to-detrainment ratio.
-//   DZ_PLUME   — vertical integration step (m).
-//   H0_PLUME   — initial plume height above the source (m), used by the
-//                surface model to set w0.
 export const A_W      = 1.0;
 export const B_W      = 0.2;
 export const FAC_ENT  = 0.8;
@@ -122,7 +115,6 @@ export function calc_entraining_parcel(
 {
     const w_eps = 1e-6;
 
-    // No buoyancy / momentum input from the surface — nothing to launch.
     if (w0_plume_s < w_eps)
         return {
             T: [], T_pseudo: [], Tv: [], Td: [],

--- a/web/parcel.js
+++ b/web/parcel.js
@@ -121,7 +121,7 @@ export function calc_entraining_parcel(
     const rho_e    = p_e.map((p, k) => p / (Rd * exner_e[k] * thetav_e[k]));
 
     // Allocate parcel arrays.
-    const theta_p  = new Array(n);
+    const thetal_p = new Array(n);
     const qt_p     = new Array(n);
     const thetav_p = new Array(n);
     const T_p      = new Array(n);
@@ -133,11 +133,12 @@ export function calc_entraining_parcel(
     const det_p    = new Array(n);
     const type_p   = new Array(n).fill(0);
 
-    // Initial conditions.
-    theta_p[0] = theta_e[0] + fire_multiplier * dtheta_plume_s;
-    qt_p[0]    = qt_e[0]    + fire_multiplier * dq_plume_s;
+    // Initial conditions. Fire perturbation is a dry heat excess (ql=0 at source),
+    // so thetal_p == theta_p at the surface.
+    thetal_p[0] = theta_e[0] + fire_multiplier * dtheta_plume_s;
+    qt_p[0]     = qt_e[0]    + fire_multiplier * dq_plume_s;
 
-    let { T, ql, qi } = sat_adjust(theta_p[0], qt_p[0], p_e[0]);
+    let { T, ql, qi } = sat_adjust(thetal_p[0], qt_p[0], p_e[0]);
     T_p[0]      = T;
     Tv_p[0]     = virtual_temp(T, qt_p[0], ql, qi);
     thetav_p[0] = Tv_p[0]/exner_e[0];
@@ -157,11 +158,14 @@ export function calc_entraining_parcel(
     let i = 1;
     for (; i < n; i++)
     {
-        mf_p[i]    = mf_p[i-1] + (ent_p[i-1] - det_p[i-1]) * dz;
-        theta_p[i] = theta_p[i-1] - ent_p[i-1] * (theta_p[i-1] - theta_e[i-1]) / mf_p[i-1] * dz;
-        qt_p[i]    = qt_p[i-1]    - ent_p[i-1] * (qt_p[i-1]    - qt_e[i-1])    / mf_p[i-1] * dz;
+        mf_p[i]     = mf_p[i-1] + (ent_p[i-1] - det_p[i-1]) * dz;
+        // TODO: use thetal_e here instead of theta_e. Currently theta_e == thetal_e only
+        // because the environment is assumed unsaturated (ql_e = 0). If the environment
+        // is saturated, entrained air carries condensate and theta_e > thetal_e.
+        thetal_p[i] = thetal_p[i-1] - ent_p[i-1] * (thetal_p[i-1] - theta_e[i-1]) / mf_p[i-1] * dz;
+        qt_p[i]     = qt_p[i-1]     - ent_p[i-1] * (qt_p[i-1]     - qt_e[i-1])    / mf_p[i-1] * dz;
 
-        ({ T, ql, qi } = sat_adjust(theta_p[i], qt_p[i], p_e[i]));
+        ({ T, ql, qi } = sat_adjust(thetal_p[i], qt_p[i], p_e[i]));
         T_p[i]      = T;
         Tv_p[i]     = virtual_temp(T, qt_p[i], ql, qi);
         thetav_p[i] = Tv_p[i] / exner_e[i];
@@ -202,7 +206,7 @@ export function calc_entraining_parcel(
         T_pseudo:    T_pseudo,
         Tv:          sl(Tv_p),
         Td:          Td_out,
-        theta:       sl(theta_p),
+        thetal:      sl(thetal_p),
         thetav:      sl(thetav_p),
         qt:          qt_out,
         area:        sl(area_p),

--- a/web/parcel.js
+++ b/web/parcel.js
@@ -166,8 +166,13 @@ export function calc_entraining_parcel(
         qt_p[i]     = qt_p[i-1]     - ent_p[i-1] * (qt_p[i-1]     - qt_e[i-1])    / mf_p[i-1] * dz;
 
         ({ T, ql, qi } = sat_adjust(thetal_p[i], qt_p[i], p_e[i]));
+
+        // Pseudoadiabatic: remove condensate so it does not accumulate in the parcel.
+        qt_p[i]    -= ql;
+        thetal_p[i] = T / exner_e[i];
+
         T_p[i]      = T;
-        Tv_p[i]     = virtual_temp(T, qt_p[i], ql, qi);
+        Tv_p[i]     = virtual_temp(T, qt_p[i], 0, 0);
         thetav_p[i] = Tv_p[i] / exner_e[i];
 
         if (ql > 0 || qi > 0)

--- a/web/parcel.js
+++ b/web/parcel.js
@@ -19,8 +19,8 @@ import { Rd, g, exner, qsat, dewpoint, calc_moist_adiabat, sat_adjust, virtual_t
 
 export const A_W      = 1.0;
 export const B_W      = 0.2;
-export const FAC_ENT  = 0.8;
-export const BETA     = 0.4;
+export const FAC_ENT  = 1;  // Non-dimensional scaling of entrainment, from Eyken (2026)
+export const BETA     = 0.5; // The ratio fractional detrainment / fractional entrainment
 export const DZ_PLUME = 50;
 export const H0_PLUME = 20;
 
@@ -166,8 +166,8 @@ export function calc_entraining_parcel(
     mf_p[0]     = rho_e[0] * area_p[0] * w_p[0];
 
     // Entrainment settings (Morton formulation).
-    const epsi = fac_ent * beta / Math.sqrt(area_plume_s);
-    const delt = epsi / beta;
+    const epsi = fac_ent / Math.sqrt(area_plume_s);
+    const delt = epsi * beta;
 
     ent_p[0] = epsi * mf_p[0];
     det_p[0] = 0.0;

--- a/web/parcel.js
+++ b/web/parcel.js
@@ -17,6 +17,21 @@
 import { Rd, g, exner, qsat, dewpoint, calc_moist_adiabat, sat_adjust, virtual_temp } from "./thermo.js";
 
 
+// Entraining plume model constants.
+//   A_W, B_W   — buoyancy and entrainment scalings of w (Morton).
+//   FAC_ENT    — fractional entrainment coefficient.
+//   BETA       — entrainment-to-detrainment ratio.
+//   DZ_PLUME   — vertical integration step (m).
+//   H0_PLUME   — initial plume height above the source (m), used by the
+//                surface model to set w0.
+export const A_W      = 1.0;
+export const B_W      = 0.2;
+export const FAC_ENT  = 0.8;
+export const BETA     = 0.4;
+export const DZ_PLUME = 50;
+export const H0_PLUME = 20;
+
+
 function interp(x, xp, fp)
 {
     // Linear interpolation of fp at positions x, given sample points xp (ascending).
@@ -94,17 +109,29 @@ export function calc_non_entraining_parcel(T_sfc, Td_sfc, p_sfc, p)
 
 export function calc_entraining_parcel(
     z_env, T_env, Td_env, p_env,
-    dtheta_plume_s, dq_plume_s, area_plume_s,
+    dtheta_plume_s, dq_plume_s, w0_plume_s, area_plume_s,
     {
         fire_multiplier = 1,
-        a_w    = 1.0,
-        b_w    = 0.2,
-        fac_ent = 0.8,
-        beta   = 0.4,
-        dz     = 50,
+        a_w    = A_W,
+        b_w    = B_W,
+        fac_ent = FAC_ENT,
+        beta   = BETA,
+        dz     = DZ_PLUME,
         z_max  = 5000,
     } = {})
 {
+    const w_eps = 1e-6;
+
+    // No buoyancy / momentum input from the surface — nothing to launch.
+    if (w0_plume_s < w_eps)
+        return {
+            T: [], T_pseudo: [], Tv: [], Td: [],
+            theta: [], thetav: [], qt: [],
+            area: [], w: [], mass_flux: [],
+            entrainment: [], detrainment: [], type: [],
+            z: [], p: [],
+        };
+
     // Build uniform height grid.
     const n = Math.floor(z_max / dz);
     const z = Array.from({ length: n }, (_, i) => i * dz);
@@ -142,7 +169,7 @@ export function calc_entraining_parcel(
     Tv_p[0]     = virtual_temp(T, qt_p[0], ql, qi);
     thetav_p[0] = Tv_p[0]/exner_e[0];
     area_p[0]   = area_plume_s;
-    w_p[0]      = 0.1;
+    w_p[0]      = w0_plume_s;
     mf_p[0]     = rho_e[0] * area_p[0] * w_p[0];
 
     // Entrainment settings (Morton formulation).
@@ -153,7 +180,6 @@ export function calc_entraining_parcel(
     det_p[0] = 0.0;
 
     // Integrate upward.
-    const w_eps = 1e-6;
     let i = 1;
     for (; i < n; i++)
     {

--- a/web/skewt.js
+++ b/web/skewt.js
@@ -459,7 +459,7 @@ function draw_skewt()
                 const lcl_idx = parcel.type.indexOf(1);
                 const n_sub   = lcl_idx === -1 ? parcel.p.length : lcl_idx + 1;
                 draw_parcel_segments([
-                    [parcel.p,                 parcel.T_pseudo],
+                    [parcel.p,                 parcel.T],
                     [parcel.p.slice(0, n_sub), parcel.Td.slice(0, n_sub)],
                 ]);
             }

--- a/web/skewt.js
+++ b/web/skewt.js
@@ -15,7 +15,8 @@
 //
 
 import { calc_non_entraining_parcel, calc_entraining_parcel } from "./parcel.js";
-import { exner, qsat } from "./thermo.js";
+import { Rd, exner, qsat, dewpoint, virtual_temp } from "./thermo.js";
+import { compute_fire_surface, invert_fire_surface } from "./fire_surface.js";
 import { draw_wind_barb, STAFF_LEN } from "./wind_barbs.js";
 
 const svg = d3.select("#skewt");
@@ -37,7 +38,11 @@ let model_sounding = null;
 let obs_sounding = null;
 let model_forecast = null;
 let current_time = 0;
-let parcel_starts = null;
+
+// Global fire surface fluxes (kW/m²). The parcel's source-level dtheta, dq
+// and w0 are derived from these on every redraw via the surface model in
+// fire_surface.js. Defaults are zero — no fire, no plume.
+const fire_state = { H: 0, LE: 0 };
 
 const color_T   = "#EB0056";
 const color_Td  = "#0056EB";
@@ -125,11 +130,6 @@ document.getElementById("fetch_model_btn").addEventListener("click", () =>
             Td_2m:               data.Td_2m[current_time],
         };
 
-        parcel_starts = data.T_2m.map((T_2m, ti) => ({
-            T:  T_2m,
-            Td: data.Td_2m[ti],
-        }));
-
         document.getElementById("launch_parcel").disabled = false;
         document.getElementById("show_model_sounding").checked = true;
         draw_skewt();
@@ -180,6 +180,33 @@ document.getElementById("fire_area").addEventListener("input", (e) =>
         `Fire area: ${area_km2} km²`;
     draw_skewt();
 });
+document.getElementById("fire_H").addEventListener("input", (e) =>
+{
+    fire_state.H = +e.target.value;
+    update_flux_labels();
+    draw_skewt();
+});
+document.getElementById("fire_LE").addEventListener("input", (e) =>
+{
+    fire_state.LE = +e.target.value;
+    update_flux_labels();
+    draw_skewt();
+});
+// Reflect fire_state -> slider DOM (after a drag updated it in-place).
+function sync_flux_controls()
+{
+    document.getElementById("fire_H").value  = fire_state.H;
+    document.getElementById("fire_LE").value = fire_state.LE;
+    update_flux_labels();
+}
+
+function update_flux_labels()
+{
+    document.getElementById("fire_H_label").textContent =
+        `Sensible heat flux: ${fire_state.H.toFixed(0)} kW/m²`;
+    document.getElementById("fire_LE_label").textContent =
+        `Latent heat flux: ${fire_state.LE.toFixed(1)} kW/m²`;
+}
 document.getElementById("show_isobars").addEventListener("change", draw_skewt);
 document.getElementById("show_isotherms").addEventListener("change", draw_skewt);
 document.getElementById("show_isohumes").addEventListener("change", () =>
@@ -395,21 +422,23 @@ function draw_skewt()
 
             const mode      = document.getElementById("parcel_mode").value;
             const p_pa_all  = model_sounding.p_hpa.map(p => p * 100);
-            const p_sfc_pa  = (model_sounding.surface_pressure_hpa ?? Math.max(...model_sounding.p_hpa)) * 100;
-            const T_s       = parcel_starts[current_time].T;
-            const Td_s      = parcel_starts[current_time].Td;
+            const surf      = get_surface_state();
+
+            // Parcel source: ambient surface + fire-driven excesses.
+            const T_s  = surf.T_env_sfc + surf.dtheta * surf.exner_sfc;
+            const Td_s = dewpoint(surf.qt_sfc + surf.dq, surf.p_sfc_pa);
 
             // Index of the first pressure level strictly above the surface.
             // p_pa_all is sorted descending (highest pressure first).
-            const idx_above = p_pa_all.findIndex(p => p < p_sfc_pa);
+            const idx_above = p_pa_all.findIndex(p => p < surf.p_sfc_pa);
 
             if (mode === "non_entraining")
             {
                 // Parcel grid: surface pressure + all levels above it.
                 const p_above = idx_above === -1 ? [] : p_pa_all.slice(idx_above);
-                const p_parcel = [p_sfc_pa, ...p_above].sort((a, b) => b - a);
+                const p_parcel = [surf.p_sfc_pa, ...p_above].sort((a, b) => b - a);
 
-                const parcel = calc_non_entraining_parcel(T_s, Td_s, p_sfc_pa, p_parcel);
+                const parcel = calc_non_entraining_parcel(T_s, Td_s, surf.p_sfc_pa, p_parcel);
 
                 draw_parcel_segments([
                     [parcel.p_dry,     parcel.T_dry],
@@ -433,27 +462,25 @@ function draw_skewt()
                     const i1 = idx_above;
                     const lp0 = Math.log(p_pa_all[i0]);
                     const lp1 = Math.log(p_pa_all[i1]);
-                    const t   = (Math.log(p_sfc_pa) - lp0) / (lp1 - lp0);
+                    const t   = (Math.log(surf.p_sfc_pa) - lp0) / (lp1 - lp0);
                     z_sfc_agl = model_sounding.z_agl[i0] + t * (model_sounding.z_agl[i1] - model_sounding.z_agl[i0]);
                 }
 
                 // Environment: surface point followed by all levels above the surface.
-                const p_env  = [p_sfc_pa, ...p_pa_all.slice(idx_above)];
-                const T_env  = [model_sounding.T_2m  ?? model_sounding.T[idx_above],  ...model_sounding.T.slice(idx_above)];
-                const Td_env = [model_sounding.Td_2m ?? model_sounding.Td[idx_above], ...model_sounding.Td.slice(idx_above)];
+                const p_env  = [surf.p_sfc_pa,  ...p_pa_all.slice(idx_above)];
+                const T_env  = [surf.T_env_sfc, ...model_sounding.T.slice(idx_above)];
+                const Td_env = [surf.Td_env_sfc, ...model_sounding.Td.slice(idx_above)];
                 const z_env  = [0, ...model_sounding.z_agl.slice(idx_above).map(z => z - z_sfc_agl)];
 
-                const T_env_sfc  = model_sounding.T_2m  ?? model_sounding.T[idx_above];
-                const Td_env_sfc = model_sounding.Td_2m ?? model_sounding.Td[idx_above];
-                const dtheta = T_s / exner(p_sfc_pa) - T_env_sfc / exner(p_sfc_pa);
-                const dq     = qsat(Td_s, p_sfc_pa) - qsat(Td_env_sfc, p_sfc_pa);
-                const area   = 10 ** +document.getElementById("fire_area").value;
+                const area = 10 ** +document.getElementById("fire_area").value;
 
                 const parcel = calc_entraining_parcel(
                     z_env, T_env, Td_env, p_env,
-                    dtheta, dq, area,
+                    surf.dtheta, surf.dq, surf.w0, area,
                     { z_max: 12000 },
                 );
+
+                if (parcel.p.length === 0) return;
 
                 // T for the full ascent; Td only below LCL (where type == 0).
                 const lcl_idx = parcel.type.indexOf(1);
@@ -463,6 +490,37 @@ function draw_skewt()
                     [parcel.p.slice(0, n_sub), parcel.Td.slice(0, n_sub)],
                 ]);
             }
+        }
+
+        // Derived surface-layer state, including the fire-driven excesses
+        // (dtheta, dq) and source-level vertical velocity w0 returned by the
+        // surface model. Recomputed each call so model edits (e.g. dragging
+        // T_2m in edit mode) propagate immediately.
+        function get_surface_state()
+        {
+            const p_sfc_pa = (model_sounding.surface_pressure_hpa ?? Math.max(...model_sounding.p_hpa)) * 100;
+            const p_pa_all = model_sounding.p_hpa.map(p => p * 100);
+            const idx_above = p_pa_all.findIndex(p => p < p_sfc_pa);
+            const fallback_idx = idx_above === -1 ? 0 : idx_above;
+
+            const T_env_sfc  = model_sounding.T_2m  ?? model_sounding.T[fallback_idx];
+            const Td_env_sfc = model_sounding.Td_2m ?? model_sounding.Td[fallback_idx];
+            const exner_sfc  = exner(p_sfc_pa);
+            const theta_sfc  = T_env_sfc / exner_sfc;
+            const qt_sfc     = qsat(Td_env_sfc, p_sfc_pa);
+            const thetav_sfc = virtual_temp(theta_sfc, qt_sfc);
+            const rho_sfc    = p_sfc_pa / (Rd * exner_sfc * thetav_sfc);
+
+            const { dtheta, dq, w0 } = compute_fire_surface(
+                fire_state.H * 1e3, fire_state.LE * 1e3,
+                rho_sfc, theta_sfc, thetav_sfc,
+            );
+
+            return {
+                p_sfc_pa, T_env_sfc, Td_env_sfc,
+                exner_sfc, theta_sfc, qt_sfc, thetav_sfc, rho_sfc,
+                dtheta, dq, w0,
+            };
         }
 
         function draw_skewt_profile(pts, color, source_T, on_surface_drag)
@@ -511,50 +569,84 @@ function draw_skewt()
                     .call(drag);
         }
 
-        const update_T_sfc  = v => { model_sounding.T_2m  = v; if (parcel_starts) parcel_starts[current_time].T  = v; };
-        const update_Td_sfc = v => { model_sounding.Td_2m = v; if (parcel_starts) parcel_starts[current_time].Td = v; };
+        const update_T_sfc  = v => { model_sounding.T_2m  = v; };
+        const update_Td_sfc = v => { model_sounding.Td_2m = v; };
 
         draw_skewt_profile(t_pts,  color_T,  model_sounding.T,  update_T_sfc);
         draw_skewt_profile(td_pts, color_Td, model_sounding.Td, update_Td_sfc);
 
         if (!document.getElementById("edit_mode").checked &&
-             document.getElementById("launch_parcel").checked &&
-             parcel_starts)
+             document.getElementById("launch_parcel").checked)
         {
             const sfc_p_hpa_marker = model_sounding.surface_pressure_hpa ?? Math.max(...model_sounding.p_hpa);
 
-            const draw_parcel_marker = (get_T, set_T, color) =>
-            {
-                const node = chart.append("circle")
-                    .attr("cx", x(skew_transform(get_T(), sfc_p_hpa_marker)))
-                    .attr("cy", y(sfc_p_hpa_marker))
-                    .attr("r", 5)
-                    .attr("fill", "white")
-                    .attr("stroke", color)
-                    .attr("stroke-width", 2)
-                    .style("cursor", "grab");
-
-                node.call(d3.drag()
-                    .on("start", function () { d3.select(this).style("cursor", "grabbing"); })
-                    .on("drag",  function (event) {
-                        set_T(inv_skew_transform(x.invert(event.x), sfc_p_hpa_marker));
-                        node.attr("cx", x(skew_transform(get_T(), sfc_p_hpa_marker)));
-                        redraw_parcel();
-                    })
-                    .on("end",   function () { d3.select(this).style("cursor", "grab"); })
-                );
+            // Initial positions from the current (H, LE).
+            const surf0  = get_surface_state();
+            const T_marker_val  = () => {
+                const s = get_surface_state();
+                return s.T_env_sfc + s.dtheta * s.exner_sfc;
+            };
+            const Td_marker_val = () => {
+                const s = get_surface_state();
+                return dewpoint(s.qt_sfc + s.dq, s.p_sfc_pa);
             };
 
-            draw_parcel_marker(
-                ()  => parcel_starts[current_time].T,
-                val => { parcel_starts[current_time].T = val; },
-                "#000"
-            );
-            draw_parcel_marker(
-                ()  => parcel_starts[current_time].Td,
-                val => { parcel_starts[current_time].Td = val; },
-                "#000"
-            );
+            const T_node = chart.append("circle")
+                .attr("cx", x(skew_transform(surf0.T_env_sfc + surf0.dtheta * surf0.exner_sfc, sfc_p_hpa_marker)))
+                .attr("cy", y(sfc_p_hpa_marker))
+                .attr("r", 5)
+                .attr("fill", "white")
+                .attr("stroke", "#000")
+                .attr("stroke-width", 2)
+                .style("cursor", "grab");
+
+            const Td_node = chart.append("circle")
+                .attr("cx", x(skew_transform(dewpoint(surf0.qt_sfc + surf0.dq, surf0.p_sfc_pa), sfc_p_hpa_marker)))
+                .attr("cy", y(sfc_p_hpa_marker))
+                .attr("r", 5)
+                .attr("fill", "white")
+                .attr("stroke", "#000")
+                .attr("stroke-width", 2)
+                .style("cursor", "grab");
+
+            const reposition_markers = () =>
+            {
+                T_node.attr("cx",  x(skew_transform(T_marker_val(),  sfc_p_hpa_marker)));
+                Td_node.attr("cx", x(skew_transform(Td_marker_val(), sfc_p_hpa_marker)));
+            };
+
+            // Drag inverts the surface model: keep the other channel's excess
+            // fixed, solve for new (H, LE). Dragging T below ambient or Td
+            // below saturation gives a non-positive excess, which the inversion
+            // clamps to (H, LE) = (0, 0) — i.e. the fire is "switched off".
+            const make_drag = (axis) => d3.drag()
+                .on("start", function () { d3.select(this).style("cursor", "grabbing"); })
+                .on("drag", function (event)
+                {
+                    const s = get_surface_state();
+                    const val_new = inv_skew_transform(x.invert(event.x), sfc_p_hpa_marker);
+                    let dtheta_new = s.dtheta;
+                    let dq_new     = s.dq;
+                    if (axis === "T")
+                        dtheta_new = (val_new - s.T_env_sfc) / s.exner_sfc;
+                    else
+                        dq_new = qsat(val_new, s.p_sfc_pa) - s.qt_sfc;
+
+                    const { H, LE } = invert_fire_surface(
+                        dtheta_new, dq_new, s.rho_sfc, s.theta_sfc, s.thetav_sfc,
+                    );
+                    const H_in  = document.getElementById("fire_H");
+                    const LE_in = document.getElementById("fire_LE");
+                    fire_state.H  = Math.min(+H_in.max,  Math.max(0, H  / 1e3));
+                    fire_state.LE = Math.min(+LE_in.max, Math.max(0, LE / 1e3));
+                    sync_flux_controls();
+                    reposition_markers();
+                    redraw_parcel();
+                })
+                .on("end", function () { d3.select(this).style("cursor", "grab"); });
+
+            T_node.call(make_drag("T"));
+            Td_node.call(make_drag("Td"));
         }
 
         redraw_parcel();
@@ -776,13 +868,6 @@ document.getElementById("match_profile_btn").addEventListener("click", () =>
             model_sounding.Td[i] = interp_log_p(p, Td_pairs);
         }
     });
-
-    if (parcel_starts && parcel_starts[current_time])
-    {
-        const sfc_idx = model_sounding.p_hpa.indexOf(Math.max(...model_sounding.p_hpa));
-        parcel_starts[current_time].T  = model_sounding.T[sfc_idx];
-        parcel_starts[current_time].Td = model_sounding.Td[sfc_idx];
-    }
 
     draw_skewt();
 });

--- a/web/skewt.js
+++ b/web/skewt.js
@@ -200,7 +200,7 @@ function sync_flux_controls()
 function update_flux_labels()
 {
     document.getElementById("fire_H_label").textContent =
-        `Sensible heat flux: ${fire_state.H.toFixed(0)} kW/m²`;
+        `Sensible heat flux: ${fire_state.H.toFixed(1)} kW/m²`;
     document.getElementById("fire_LE_label").textContent =
         `Latent heat flux: ${fire_state.LE.toFixed(1)} kW/m²`;
 }

--- a/web/skewt.js
+++ b/web/skewt.js
@@ -39,9 +39,6 @@ let obs_sounding = null;
 let model_forecast = null;
 let current_time = 0;
 
-// Global fire surface fluxes (kW/m²). The parcel's source-level dtheta, dq
-// and w0 are derived from these on every redraw via the surface model in
-// fire_surface.js. Defaults are zero — no fire, no plume.
 const fire_state = { H: 0, LE: 0 };
 
 const color_T   = "#EB0056";
@@ -424,7 +421,6 @@ function draw_skewt()
             const p_pa_all  = model_sounding.p_hpa.map(p => p * 100);
             const surf      = get_surface_state();
 
-            // Parcel source: ambient surface + fire-driven excesses.
             const T_s  = surf.T_env_sfc + surf.dtheta * surf.exner_sfc;
             const Td_s = dewpoint(surf.qt_sfc + surf.dq, surf.p_sfc_pa);
 
@@ -492,10 +488,6 @@ function draw_skewt()
             }
         }
 
-        // Derived surface-layer state, including the fire-driven excesses
-        // (dtheta, dq) and source-level vertical velocity w0 returned by the
-        // surface model. Recomputed each call so model edits (e.g. dragging
-        // T_2m in edit mode) propagate immediately.
         function get_surface_state()
         {
             const p_sfc_pa = (model_sounding.surface_pressure_hpa ?? Math.max(...model_sounding.p_hpa)) * 100;
@@ -580,7 +572,6 @@ function draw_skewt()
         {
             const sfc_p_hpa_marker = model_sounding.surface_pressure_hpa ?? Math.max(...model_sounding.p_hpa);
 
-            // Initial positions from the current (H, LE).
             const surf0  = get_surface_state();
             const T_marker_val  = () => {
                 const s = get_surface_state();
@@ -615,10 +606,6 @@ function draw_skewt()
                 Td_node.attr("cx", x(skew_transform(Td_marker_val(), sfc_p_hpa_marker)));
             };
 
-            // Drag inverts the surface model: keep the other channel's excess
-            // fixed, solve for new (H, LE). Dragging T below ambient or Td
-            // below saturation gives a non-positive excess, which the inversion
-            // clamps to (H, LE) = (0, 0) — i.e. the fire is "switched off".
             const make_drag = (axis) => d3.drag()
                 .on("start", function () { d3.select(this).style("cursor", "grabbing"); })
                 .on("drag", function (event)

--- a/web/skewt.js
+++ b/web/skewt.js
@@ -16,7 +16,7 @@
 
 import { calc_non_entraining_parcel, calc_entraining_parcel } from "./parcel.js";
 import { Rd, exner, qsat, dewpoint, virtual_temp } from "./thermo.js";
-import { compute_fire_surface, invert_fire_surface } from "./fire_surface.js";
+import { w0_from_dtheta, dtheta_from_H, dq_from_LE, H_from_dtheta, LE_from_dq } from "./fire_surface.js";
 import { draw_wind_barb, STAFF_LEN } from "./wind_barbs.js";
 
 const svg = d3.select("#skewt");
@@ -39,7 +39,7 @@ let obs_sounding = null;
 let model_forecast = null;
 let current_time = 0;
 
-const fire_state = { H: 0, LE: 0 };
+const fire_state = { dtheta: 0, dq: 0 };
 
 const color_T   = "#EB0056";
 const color_Td  = "#0056EB";
@@ -179,30 +179,38 @@ document.getElementById("fire_area").addEventListener("input", (e) =>
 });
 document.getElementById("fire_H").addEventListener("input", (e) =>
 {
-    fire_state.H = +e.target.value;
-    update_flux_labels();
+    const base = get_surface_base();
+    if (base)
+        fire_state.dtheta = dtheta_from_H(+e.target.value * 1e3, base.rho_sfc, base.thetav_sfc);
+    sync_flux_controls();
     draw_skewt();
 });
 document.getElementById("fire_LE").addEventListener("input", (e) =>
 {
-    fire_state.LE = +e.target.value;
-    update_flux_labels();
+    const base = get_surface_base();
+    if (base)
+        fire_state.dq = dq_from_LE(+e.target.value * 1e3, fire_state.dtheta, base.rho_sfc, base.thetav_sfc);
+    sync_flux_controls();
     draw_skewt();
 });
-// Reflect fire_state -> slider DOM (after a drag updated it in-place).
+
 function sync_flux_controls()
 {
-    document.getElementById("fire_H").value  = fire_state.H;
-    document.getElementById("fire_LE").value = fire_state.LE;
-    update_flux_labels();
+    const base = get_surface_base();
+    if (!base) return;
+    const H_kw  = H_from_dtheta(fire_state.dtheta, base.rho_sfc, base.thetav_sfc) / 1e3;
+    const LE_kw = LE_from_dq(fire_state.dq, fire_state.dtheta, base.rho_sfc, base.thetav_sfc) / 1e3;
+    document.getElementById("fire_H").value  = H_kw;
+    document.getElementById("fire_LE").value = LE_kw;
+    update_flux_labels(H_kw, LE_kw);
 }
 
-function update_flux_labels()
+function update_flux_labels(H_kw, LE_kw)
 {
     document.getElementById("fire_H_label").textContent =
-        `Sensible heat flux: ${fire_state.H.toFixed(1)} kW/m²`;
+        `Sensible heat flux: ${H_kw.toFixed(1)} kW/m²`;
     document.getElementById("fire_LE_label").textContent =
-        `Latent heat flux: ${fire_state.LE.toFixed(1)} kW/m²`;
+        `Latent heat flux: ${LE_kw.toFixed(1)} kW/m²`;
 }
 document.getElementById("show_isobars").addEventListener("change", draw_skewt);
 document.getElementById("show_isotherms").addEventListener("change", draw_skewt);
@@ -298,6 +306,27 @@ function draw_isohume_labels(chart, x, y, isohumes, p_isohumes_pa, mixing_ratios
             .attr("fill", "rgba(31,119,180,0.9)")
             .text(mixing_ratios[i].toFixed(1));
     });
+}
+
+// Returns surface thermodynamic base state from model_sounding, or null if unavailable.
+function get_surface_base()
+{
+    if (!model_sounding) return null;
+
+    const p_sfc_pa = (model_sounding.surface_pressure_hpa ?? Math.max(...model_sounding.p_hpa)) * 100;
+    const p_pa_all = model_sounding.p_hpa.map(p => p * 100);
+    const idx_above = p_pa_all.findIndex(p => p < p_sfc_pa);
+    const fallback_idx = idx_above === -1 ? 0 : idx_above;
+
+    const T_env_sfc  = model_sounding.T_2m  ?? model_sounding.T[fallback_idx];
+    const Td_env_sfc = model_sounding.Td_2m ?? model_sounding.Td[fallback_idx];
+    const exner_sfc  = exner(p_sfc_pa);
+    const theta_sfc  = T_env_sfc / exner_sfc;
+    const qt_sfc     = qsat(Td_env_sfc, p_sfc_pa);
+    const thetav_sfc = virtual_temp(theta_sfc, qt_sfc);
+    const rho_sfc    = p_sfc_pa / (Rd * exner_sfc * thetav_sfc);
+
+    return { p_sfc_pa, T_env_sfc, Td_env_sfc, exner_sfc, theta_sfc, qt_sfc, thetav_sfc, rho_sfc };
 }
 
 function draw_skewt()
@@ -490,29 +519,9 @@ function draw_skewt()
 
         function get_surface_state()
         {
-            const p_sfc_pa = (model_sounding.surface_pressure_hpa ?? Math.max(...model_sounding.p_hpa)) * 100;
-            const p_pa_all = model_sounding.p_hpa.map(p => p * 100);
-            const idx_above = p_pa_all.findIndex(p => p < p_sfc_pa);
-            const fallback_idx = idx_above === -1 ? 0 : idx_above;
-
-            const T_env_sfc  = model_sounding.T_2m  ?? model_sounding.T[fallback_idx];
-            const Td_env_sfc = model_sounding.Td_2m ?? model_sounding.Td[fallback_idx];
-            const exner_sfc  = exner(p_sfc_pa);
-            const theta_sfc  = T_env_sfc / exner_sfc;
-            const qt_sfc     = qsat(Td_env_sfc, p_sfc_pa);
-            const thetav_sfc = virtual_temp(theta_sfc, qt_sfc);
-            const rho_sfc    = p_sfc_pa / (Rd * exner_sfc * thetav_sfc);
-
-            const { dtheta, dq, w0 } = compute_fire_surface(
-                fire_state.H * 1e3, fire_state.LE * 1e3,
-                rho_sfc, theta_sfc, thetav_sfc,
-            );
-
-            return {
-                p_sfc_pa, T_env_sfc, Td_env_sfc,
-                exner_sfc, theta_sfc, qt_sfc, thetav_sfc, rho_sfc,
-                dtheta, dq, w0,
-            };
+            const base = get_surface_base();
+            const w0 = w0_from_dtheta(fire_state.dtheta, base.thetav_sfc);
+            return { ...base, dtheta: fire_state.dtheta, dq: fire_state.dq, w0 };
         }
 
         function draw_skewt_profile(pts, color, source_T, on_surface_drag)
@@ -612,25 +621,15 @@ function draw_skewt()
                 {
                     const s = get_surface_state();
                     const val_new = inv_skew_transform(x.invert(event.x), sfc_p_hpa_marker);
-                    let dtheta_new = s.dtheta;
-                    let dq_new     = s.dq;
                     if (axis === "T")
-                        dtheta_new = (val_new - s.T_env_sfc) / s.exner_sfc;
+                        fire_state.dtheta = Math.max(0, (val_new - s.T_env_sfc) / s.exner_sfc);
                     else
-                        dq_new = qsat(val_new, s.p_sfc_pa) - s.qt_sfc;
-
-                    const { H, LE } = invert_fire_surface(
-                        dtheta_new, dq_new, s.rho_sfc, s.theta_sfc, s.thetav_sfc,
-                    );
-                    const H_in  = document.getElementById("fire_H");
-                    const LE_in = document.getElementById("fire_LE");
-                    fire_state.H  = Math.min(+H_in.max,  Math.max(0, H  / 1e3));
-                    fire_state.LE = Math.min(+LE_in.max, Math.max(0, LE / 1e3));
+                        fire_state.dq = Math.max(0, qsat(val_new, s.p_sfc_pa) - s.qt_sfc);
                     sync_flux_controls();
                     reposition_markers();
                     redraw_parcel();
                 })
-                .on("end", function () { d3.select(this).style("cursor", "grab"); });
+                .on("end", function () { d3.select(this).style("cursor", "grab"); draw_skewt(); });
 
             T_node.call(make_drag("T"));
             Td_node.call(make_drag("Td"));

--- a/web/thermo.js
+++ b/web/thermo.js
@@ -79,9 +79,16 @@ export function virtual_temp(T, qt, ql=0, qi=0)
 }
 
 
-export function sat_adjust(thl, qt, p)
+export function thetal(theta, ql, T)
 {
-    const tl = thl * exner(p);
+    return theta * Math.exp(-Lv * ql / (cp * T));
+}
+
+
+export function sat_adjust(thetal, qt, p)
+{
+    const pi = exner(p);
+    const tl = thetal * pi;
     let qs = qsat(tl, p);
 
     if (qt - qs <= 0.0)
@@ -94,8 +101,10 @@ export function sat_adjust(thl, qt, p)
         niter++;
         tnr_old = tnr;
         qs = qsat(tnr, p);
-        const f       = tnr - tl - Lv / cp * (qt - qs);
-        const f_prime = 1.0 + Lv / cp * dqsatdT(tnr, p);
+        const ql    = qt - qs;
+        const exp_A = Math.exp(-Lv * ql / (cp * tnr));
+        const f       = tnr * exp_A - tl;
+        const f_prime = exp_A * (1.0 + Lv / cp * (dqsatdT(tnr, p) + ql / tnr));
         tnr -= f / f_prime;
     }
 


### PR DESCRIPTION
A suggested starting point for the surface model. This PR:
- Adds `web/fire_surface.js` to handle surface model calculations. It now has two functions, which translate between (H, LE) and (dtheta, dq), depending on which pair is known, and always calculates `w0` as a result.
- Ties parcel initialisation to `H` and `LE`, the idea being that the surface needs to be warmed/moistened wrt the 2m reference `T` or `Td` (by a fire) in order for parcels to launch. The code does this by now keeping track of `fire_state = {H, LE}`, which replaces `parcel_starts`, and it will only launch entraining parcels when `H` or `LE` are enough to give a significant `w` at the top of the surface layer.
- The `calc_entraining_parcel` now always always expects a surface model to give it excesses and `w`.
- Dragging the surface parcel and sliding the H/LE sliders are tied together: You can update one and then the other responds so the computed and rendered state is always consistent. This is handled by a new function, `get_surface_state()`, which recomputes the ambient plus excess at each redraw, and some updates in `draw_skewt()`. A parcel marker drag now results in a `dthetal` and `dqt`, which go separately into the inverse surface model to calculate `H` and `LE`. These are then clamped to the slider range, the clamped excesses are fed to the correct plume model, the sliders are synced, the markers repositioned, and the curve drawn again.
- The PR has merged in the proposed changes in #40, so it might need a merge/rebase to be clean.
- I also added the entrainment you would infer from Jonathan's thesis (about a factor 10 higher than it was), since we now are explicitly lifting from given surface fluxes and size to plume properties, and that translation should match what he found at least a little bit.

I have tested a bunch of cases and this seems to behave as I expect it to. The main consequence we should maybe discuss is that the current ranges for `H` and `LE` set the minimum fluxes to zero, and this does not allow you to lift a parcel colder than the sounding. You may want to be able to do this if you want to be able to launch any parcel, but I actually don't mind not allowing it for fire cases, where `H<0` is not sensible. Also let me know what you think of the layout. Does it make sense?

If you think so, the next step could be to add Marc's actual surface model, i.e. how he translates fuel properties and near-surface meteo into heat and moisture fluxes. Reflecting the rest of the model, those heat/moisture fluxes could set the default state of the parcel in a given sounding, and the user can then drag around that state for sensitivity analyses.